### PR TITLE
update FileEnumerator.cpp

### DIFF
--- a/FileEnumerator.cpp
+++ b/FileEnumerator.cpp
@@ -8,8 +8,13 @@ void eoraptor::FileEnumerator::EnumerateFilesAtPath(const std::wstring& path, co
 	
 	if (findHandle.get() == INVALID_HANDLE_VALUE)
 	{
-		std::system_error& e = std::system_error(std::error_code(GetLastError(), std::system_category()));
-		printf("%s: %s\n\n", path.c_str, e.what());
+		std::system_error& err = std::system_error(std::error_code(GetLastError(), std::system_category()));
+		const wchar_t* err_path = path.c_str();
+		size_t len = wcslen(err_path) * 2 + 2;
+		size_t c_len;
+		char* errmsg = new char[len];
+		wcstombs_s(&c_len, errmsg, len, err_path, len);
+		printf("%s: %s\n\n", errmsg, err.what());
 		return;
 	}
 

--- a/FileEnumerator.cpp
+++ b/FileEnumerator.cpp
@@ -5,16 +5,10 @@ void eoraptor::FileEnumerator::EnumerateFilesAtPath(const std::wstring& path, co
 {
 	WIN32_FIND_DATA findData = {};
 	unique_handle findHandle(FindFirstFile((path + L"\\*").c_str(), &findData), FindClose);
-	
+
 	if (findHandle.get() == INVALID_HANDLE_VALUE)
 	{
-		std::system_error& err = std::system_error(std::error_code(GetLastError(), std::system_category()));
-		const wchar_t* err_path = path.c_str();
-		size_t len = wcslen(err_path) * 2 + 2;
-		size_t c_len;
-		char* errmsg = new char[len];
-		wcstombs_s(&c_len, errmsg, len, err_path, len);
-		printf("%s: %s\n\n", errmsg, err.what());
+		callback(std::wstring(path), &std::system_error(std::error_code(GetLastError(), std::system_category())));
 		return;
 	}
 
@@ -37,7 +31,7 @@ void eoraptor::FileEnumerator::EnumerateFilesAtPath(const std::wstring& path, co
 					{
 						wchar_t combinedPath[MAX_PATH] = {};
 						PathCombine(combinedPath, path.c_str(), findData.cFileName);
-						callback(std::wstring(combinedPath));
+						callback(std::wstring(combinedPath), NULL);
 					}
 				}
 			}

--- a/FileEnumerator.cpp
+++ b/FileEnumerator.cpp
@@ -8,7 +8,9 @@ void eoraptor::FileEnumerator::EnumerateFilesAtPath(const std::wstring& path, co
 	
 	if (findHandle.get() == INVALID_HANDLE_VALUE)
 	{
-		throw std::system_error(std::error_code(GetLastError(), std::system_category()));
+		std::system_error& e = std::system_error(std::error_code(GetLastError(), std::system_category()));
+		printf("%s: %s\n\n", path.c_str, e.what());
+		return;
 	}
 
 	do

--- a/FileEnumerator.h
+++ b/FileEnumerator.h
@@ -2,7 +2,7 @@
 
 namespace eoraptor
 {
-	using FileEnumeratorCallback = std::function<void(std::wstring filePath)>;
+	using FileEnumeratorCallback = std::function<void(std::wstring filePath, std::system_error* error)>;
 
 	class FileEnumerator {
 	public:

--- a/eoraptor.cpp
+++ b/eoraptor.cpp
@@ -14,8 +14,13 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
 
 	try
 	{
-		fileEnumerator.EnumerateFilesAtPath(argv[1], [&imageEnumerator, &totalBytesWasted](const std::wstring& filePath) {
+		fileEnumerator.EnumerateFilesAtPath(argv[1], [&imageEnumerator, &totalBytesWasted](const std::wstring& filePath, const std::system_error* error) {
 			wprintf(L"%s\n", filePath.c_str());
+
+			if (error != NULL) {
+				printf("Error: %s", error->what());
+				return;
+			}
 
 			size_t moduleBytesWasted = 0;
 			imageEnumerator.EnumerateImageResourcesInFile(filePath, [&filePath, &moduleBytesWasted, &totalBytesWasted](const void* resourcePtr, size_t size, long resourceId) {


### PR DESCRIPTION
fixes #3

this patch turns the throw in FileEnumerator into a return to allow the process to continue with other paths